### PR TITLE
Change Op encoding from c style enum to enum with values.

### DIFF
--- a/src/lox_vector.rs
+++ b/src/lox_vector.rs
@@ -94,7 +94,7 @@ impl<T> DerefMut for LoxVector<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::chunk::OpCode;
+    use crate::op::Op;
 
     use super::*;
 
@@ -108,34 +108,34 @@ mod tests {
     #[test]
     fn write_chunk() {
         let mut vec = LoxVector::new();
-        vec.push(OpCode::Return);
+        vec.push(Op::Return);
         assert_eq!(vec.capacity, 8);
         assert_eq!(vec.len(), 1);
-        assert_eq!(vec[0], OpCode::Return)
+        assert_eq!(vec[0], Op::Return)
     }
 
     #[test]
     fn grow() {
         let mut vec = LoxVector::new();
-        vec.push(OpCode::Return);
-        vec.push(OpCode::Return);
-        vec.push(OpCode::Return);
-        vec.push(OpCode::Return);
-        vec.push(OpCode::Return);
-        vec.push(OpCode::Return);
-        vec.push(OpCode::Return);
-        vec.push(OpCode::Return);
-        vec.push(OpCode::Constant);
+        vec.push(Op::Return);
+        vec.push(Op::Return);
+        vec.push(Op::Return);
+        vec.push(Op::Return);
+        vec.push(Op::Return);
+        vec.push(Op::Return);
+        vec.push(Op::Return);
+        vec.push(Op::Return);
+        vec.push(Op::Constant(1));
         assert_eq!(vec.len(), 9);
-        assert_eq!(vec[8], OpCode::Constant);
+        assert_eq!(vec[8], Op::Constant(1));
         assert_eq!(vec.capacity, 16);
     }
 
     #[test]
     fn slices_work() {
         let mut vec = LoxVector::new();
-        vec.push(OpCode::Return);
-        vec[0] = OpCode::Constant;
-        assert_eq!(vec[0], OpCode::Constant);
+        vec.push(Op::Return);
+        vec[0] = Op::Constant(1);
+        assert_eq!(vec[0], Op::Constant(1));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,20 @@
 use chunk::Chunk;
 use miette::{NamedSource, SourceSpan};
+use op::Op;
 use tracing::{debug, Level};
 use tracing_subscriber::FmtSubscriber;
 
 mod chunk;
 mod lox_vector;
 mod memory;
+mod op;
 mod value;
 fn main() {
     let subscriber = FmtSubscriber::builder()
         .with_max_level(Level::TRACE)
         .finish();
 
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+    tracing::subscriber::set_global_default(subscriber).unwrap();
 
     let src = "return 1.1;
 return 1.1;
@@ -25,18 +27,17 @@ return;
     let _ = chunk.add_constant(0.0);
     let _ = chunk.add_constant(0.0);
     let _ = chunk.add_constant(0.0);
-    chunk.write_op_code(chunk::OpCode::Return, SourceSpan::from((0, 6)));
+    chunk.write(Op::Return, SourceSpan::from((0, 6)));
     let constant = chunk.add_constant(1.1);
-    chunk.write_op_code(chunk::OpCode::Constant, SourceSpan::from((7, 3)));
-    chunk.write(constant, SourceSpan::from((7, 3)));
-    chunk.write_op_code(chunk::OpCode::Return, SourceSpan::from((12, 6)));
+    chunk.write(Op::Constant(constant), SourceSpan::from((7, 3)));
+    chunk.write(Op::Return, SourceSpan::from((12, 6)));
     let constant = chunk.add_constant(1.1);
-    chunk.write_op_code(chunk::OpCode::Constant, SourceSpan::from((19, 3)));
-    chunk.write(constant, SourceSpan::from((19, 3)));
-    chunk.write_op_code(chunk::OpCode::Return, SourceSpan::from((24, 6)));
+    chunk.write(Op::Constant(constant), SourceSpan::from((19, 3)));
+    chunk.write(Op::Return, SourceSpan::from((24, 6)));
     chunk.disassemble(&src);
 
     debug!("{}", chunk.disassemble_at(&src, 0));
     debug!("{}", chunk.disassemble_at(&src, 1));
-    debug!("{}", chunk.disassemble_at(&src, 3));
+    debug!("{}", chunk.disassemble_at(&src, 2));
+    debug!("{}", chunk.disassemble_at(&src, 4));
 }

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Op {
+    Return,
+    Constant(u8),
+}


### PR DESCRIPTION
This increases bytecodesize by at least factor 2 but makes everything
much easier. Unsure whether this makes a performance difference on 64
bit machines anyways.
